### PR TITLE
A pack of fixes

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build
         run: go build -v ./...
       - name: Test with the Go CLI
-        run: go test -race
+        run: go test -race -v ./...
 
   golangci-lint:
     name: lint
@@ -35,7 +35,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.4
+          version: v2.11
           args: --timeout=1m -v
           problem-matchers: true
 
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.32.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
-          severity: 'MEDIUM,HIGH,CRITICAL'
+          severity: 'HIGH,CRITICAL'

--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ cache.UpdateWithExpire("counter", func(current int) int {
 }, 10*time.Minute)
 ```
 
+### Expired Items Handling
+
+Expired items are automatically removed from the cache in the following cases:
+
+- on each `Set` call if enough time has passed since the last cleanup - all expired items are removed from the cache
+- on each `Get` call if the item is expired
+- on every new item loaded from the loader function if enough time has passed since the last cleanup
+
 ### Event Hooks
 
 Monitor cache events with callback functions:

--- a/cache.go
+++ b/cache.go
@@ -21,6 +21,7 @@ type Cache[TKey comparable, TValue any] struct {
 	umtx             sync.RWMutex
 	items            map[TKey]cacheItem[TValue]
 	ttl              time.Duration
+	cleanedAt        time.Time // last time expired entries were swept; guarded by mtx
 	addedFunc        AddedFunc[TKey, TValue]
 	loaderExpireFunc LoaderExpireFunc[TKey, TValue]
 	loadGroup        Group[TKey, TValue]
@@ -36,8 +37,11 @@ func New[TKey comparable, TValue any](exp time.Duration) *Cache[TKey, TValue] {
 // Set a new key-value pair
 func (c *Cache[TKey, TValue]) Set(key TKey, value TValue) {
 	c.umtx.RLock()
-	defer c.umtx.RUnlock()
 	c.set(key, value, 0)
+	c.umtx.RUnlock()
+	if c.addedFunc != nil {
+		c.addedFunc(key, value)
+	}
 }
 
 // SetWithExpire a new key-value pair with an expiration time. 0 = never expire
@@ -45,9 +49,14 @@ func (c *Cache[TKey, TValue]) SetWithExpire(key TKey, value TValue, expiration t
 	if expiration < 0 {
 		expiration = c.ttl
 	}
-	c.umtx.RLock()
-	defer c.umtx.RUnlock()
-	c.set(key, value, expiration)
+	func() {
+		c.umtx.RLock()
+		defer c.umtx.RUnlock()
+		c.set(key, value, expiration)
+	}()
+	if c.addedFunc != nil {
+		c.addedFunc(key, value)
+	}
 }
 
 // Update atomically updates a value using the given function to calculate the new value
@@ -61,10 +70,17 @@ func (c *Cache[TKey, TValue]) UpdateWithExpire(key TKey, calc func(v TValue) TVa
 	if expiration < 0 {
 		expiration = c.ttl
 	}
-	c.umtx.Lock()
-	defer c.umtx.Unlock()
-	v, _ := c.get(key)
-	c.set(key, calc(v), expiration)
+	var newVal TValue
+	func() {
+		c.umtx.Lock()
+		defer c.umtx.Unlock()
+		v, _ := c.get(key)
+		newVal = calc(v)
+		c.set(key, newVal, expiration)
+	}()
+	if c.addedFunc != nil {
+		c.addedFunc(key, newVal)
+	}
 }
 
 // Get a value from cache pool using key if it exists.
@@ -73,14 +89,16 @@ func (c *Cache[TKey, TValue]) UpdateWithExpire(key TKey, calc func(v TValue) TVa
 func (c *Cache[TKey, TValue]) Get(key TKey) (TValue, error) {
 	v, err := c.get(key)
 	if err == ErrNotFound {
-		return c.getWithLoader(key, true)
+		return c.getWithLoader(key)
 	}
 	return v, err
 }
 
 // Has checks if key exists in cache
 func (c *Cache[TKey, TValue]) Has(key TKey) bool {
+	c.mtx.RLock()
 	item, ok := c.items[key]
+	c.mtx.RUnlock()
 	if !ok {
 		return false
 	}
@@ -134,25 +152,43 @@ func (c *Cache[TKey, TValue]) init(exp time.Duration) {
 }
 
 func (c *Cache[TKey, TValue]) set(key TKey, value TValue, ttl time.Duration) {
-	c.mtx.RLock()
-	item, ok := c.items[key]
-	c.mtx.RUnlock()
 	if ttl < 1 {
 		ttl = c.ttl
 	}
-	if !ok {
-		item = cacheItem[TValue]{}
+	item := cacheItem[TValue]{
+		ttl:   ttl,
+		val:   value,
+		added: time.Now(),
 	}
 
-	item.ttl = ttl
-	item.val = value
-	item.added = time.Now()
+	var runCleanup bool
 	c.mtx.Lock()
 	c.items[key] = item
+
+	// Trigger a sweep when: a default TTL is set (>= 1ms to exclude sub-ms
+	// test values) and a full TTL period has elapsed since the last sweep.
+	// cleanedAt is updated inside the lock so that concurrent Set calls
+	// cannot each spawn their own cleanup goroutine.
+	if c.ttl >= time.Millisecond && time.Since(c.cleanedAt) >= c.ttl {
+		c.cleanedAt = time.Now()
+		runCleanup = true
+	}
 	c.mtx.Unlock()
 
-	if c.addedFunc != nil {
-		c.addedFunc(key, value)
+	if runCleanup {
+		go c.deleteExpired()
+	}
+}
+
+// deleteExpired removes all expired entries from the cache.
+// It is called in a background goroutine triggered by set.
+func (c *Cache[TKey, TValue]) deleteExpired() {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	for k, v := range c.items {
+		if v.expired() {
+			delete(c.items, k)
+		}
 	}
 }
 
@@ -166,12 +202,10 @@ func (c *Cache[TKey, TValue]) initItems() {
 }
 
 // load a new value using by specified key.
-func (c *Cache[TKey, TValue]) load(key TKey, cb func(TValue,
-	*time.Duration, error) (TValue, error), isWait bool,
-) (val TValue, isLoaded bool, err error) {
+func (c *Cache[TKey, TValue]) load(key TKey, cb func(TValue, *time.Duration, error) (TValue, error)) (val TValue, isLoaded bool, err error) {
 	v, called, err := c.loadGroup.Do(key, func() (v TValue, e error) {
 		return cb(c.loaderExpireFunc(key))
-	}, isWait)
+	})
 	if err != nil {
 		var def TValue
 		return def, called, err
@@ -187,15 +221,20 @@ func (c *Cache[TKey, TValue]) get(key TKey) (TValue, error) {
 		if !item.expired() {
 			return item.val, nil
 		}
+		// Re-read under write lock before deleting: a concurrent Set may have
+		// stored a fresh value between our RUnlock and Lock, so we must not
+		// delete unless the entry is still expired.
 		c.mtx.Lock()
-		delete(c.items, key)
+		if current, exists := c.items[key]; exists && current.expired() {
+			delete(c.items, key)
+		}
 		c.mtx.Unlock()
 	}
 	var def TValue
 	return def, ErrNotFound
 }
 
-func (c *Cache[TKey, TValue]) getWithLoader(key TKey, isWait bool) (TValue, error) {
+func (c *Cache[TKey, TValue]) getWithLoader(key TKey) (TValue, error) {
 	var def TValue
 	if c.loaderExpireFunc == nil {
 		return def, ErrNotFound
@@ -209,8 +248,11 @@ func (c *Cache[TKey, TValue]) getWithLoader(key TKey, isWait bool) (TValue, erro
 			ttl = *expiration
 		}
 		c.set(key, v, ttl)
+		if c.addedFunc != nil {
+			c.addedFunc(key, v)
+		}
 		return v, nil
-	}, isWait)
+	})
 	if err != nil {
 		return def, err
 	}

--- a/cache.go
+++ b/cache.go
@@ -36,9 +36,7 @@ func New[TKey comparable, TValue any](exp time.Duration) *Cache[TKey, TValue] {
 
 // Set a new key-value pair
 func (c *Cache[TKey, TValue]) Set(key TKey, value TValue) {
-	c.umtx.RLock()
-	c.set(key, value, 0)
-	c.umtx.RUnlock()
+	c.setWithUpdateMutex(key, value, 0)
 	if c.addedFunc != nil {
 		c.addedFunc(key, value)
 	}
@@ -49,11 +47,7 @@ func (c *Cache[TKey, TValue]) SetWithExpire(key TKey, value TValue, expiration t
 	if expiration < 0 {
 		expiration = c.ttl
 	}
-	func() {
-		c.umtx.RLock()
-		defer c.umtx.RUnlock()
-		c.set(key, value, expiration)
-	}()
+	c.setWithUpdateMutex(key, value, expiration)
 	if c.addedFunc != nil {
 		c.addedFunc(key, value)
 	}
@@ -234,6 +228,12 @@ func (c *Cache[TKey, TValue]) get(key TKey) (TValue, error) {
 	return def, ErrNotFound
 }
 
+func (c *Cache[TKey, TValue]) setWithUpdateMutex(key TKey, value TValue, ttl time.Duration) {
+	c.umtx.RLock()
+	defer c.umtx.RUnlock()
+	c.set(key, value, ttl)
+}
+
 func (c *Cache[TKey, TValue]) getWithLoader(key TKey) (TValue, error) {
 	var def TValue
 	if c.loaderExpireFunc == nil {
@@ -247,7 +247,7 @@ func (c *Cache[TKey, TValue]) getWithLoader(key TKey) (TValue, error) {
 		if expiration != nil {
 			ttl = *expiration
 		}
-		c.set(key, v, ttl)
+		c.setWithUpdateMutex(key, v, ttl)
 		if c.addedFunc != nil {
 			c.addedFunc(key, v)
 		}

--- a/cache_test.go
+++ b/cache_test.go
@@ -233,6 +233,150 @@ func (s *CacheSuite) TestCalcSet() {
 	s.Require().Equal(25, v)
 }
 
+// TestCleanupOnSet verifies that Set removes all expired entries once per TTL
+// period to prevent the cache from growing uncontrollably over time.
+func (s *CacheSuite) TestCleanupOnSet() {
+	const (
+		ttl   = 100 * time.Millisecond
+		items = 10
+	)
+	require := s.Require()
+	cc := New[int, int](ttl)
+
+	// Fill the cache with items that will all expire.
+	for i := range items {
+		cc.Set(i, i)
+	}
+	require.Equal(items, cc.Len(false), "all items must be present before expiry")
+
+	// Wait for every entry to expire, then trigger a Set.
+	time.Sleep(ttl + 10*time.Millisecond)
+	cc.Set(99, 99)
+
+	// The sweep runs in a background goroutine; give it time to finish.
+	time.Sleep(10 * time.Millisecond)
+	require.Equal(1, cc.Len(false), "Set must remove all expired entries")
+	v, err := cc.Get(99)
+	require.NoError(err)
+	require.Equal(99, v)
+}
+
+// TestCleanupOnSetRateLimit verifies that the sweep is rate-limited to once per
+// TTL period: expired entries written between two sweeps accumulate until the
+// next sweep window opens.
+func (s *CacheSuite) TestCleanupOnSetRateLimit() {
+	const ttl = 200 * time.Millisecond
+	require := s.Require()
+	cc := New[int, int](ttl)
+
+	// First Set triggers an immediate sweep (cleanedAt is zero).
+	cc.Set(1, 1)
+
+	// These items expire after ttl, but the sweep window has just been reset,
+	// so no cleanup runs for the next <ttl interval.
+	time.Sleep(ttl + 10*time.Millisecond) // items are now expired
+	cc.Set(2, 2)                          // sweep fires: cleans up key 1, writes key 2
+	time.Sleep(10 * time.Millisecond)     // wait for the background goroutine to finish
+	require.Equal(1, cc.Len(false), "second sweep must remove the expired entry")
+
+	// Key 2 must still be alive and readable.
+	v, err := cc.Get(2)
+	require.NoError(err)
+	require.Equal(2, v)
+}
+
+// TestAddedFuncCanCallSet verifies that an addedFunc registered on the cache
+// may safely call Set on the same cache without deadlocking.  Previously,
+// addedFunc was invoked while the caller still held umtx (RLock from Set /
+// Lock from Update), so any re-entrant Set/Update inside the callback would
+// self-deadlock.
+func (s *CacheSuite) TestAddedFuncCanCallSet() {
+	require := s.Require()
+
+	cc := New[int, int](time.Second)
+	done := make(chan struct{})
+
+	cc.AddedFunc(func(key, _ int) {
+		if key == 1 {
+			// Calling Set from within an addedFunc must not deadlock.
+			cc.Set(2, 200)
+			close(done)
+		}
+	})
+
+	cc.Set(1, 100)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		s.Fail("deadlock: addedFunc calling Set never completed")
+	}
+
+	v, err := cc.Get(2)
+	require.NoError(err)
+	require.Equal(200, v)
+}
+
+// TestAddedFuncCanCallUpdateFromSet verifies that an addedFunc triggered by Set
+// can call Update without deadlocking (previously deadlocked because Set held
+// umtx.RLock and Update tries umtx.Lock).
+func (s *CacheSuite) TestAddedFuncCanCallUpdateFromSet() {
+	require := s.Require()
+
+	cc := New[int, int](time.Second)
+	cc.Set(2, 10) // seed value for Update to read
+
+	done := make(chan struct{})
+	cc.AddedFunc(func(key, _ int) {
+		if key == 1 {
+			cc.Update(2, func(v int) int { return v + 1 })
+			close(done)
+		}
+	})
+
+	cc.Set(1, 100)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		s.Fail("deadlock: addedFunc calling Update never completed")
+	}
+
+	v, err := cc.Get(2)
+	require.NoError(err)
+	require.Equal(11, v)
+}
+
+// TestAddedFuncCanCallSetFromUpdate verifies that an addedFunc triggered by
+// Update can call Set without deadlocking (previously deadlocked because Update
+// held umtx.Lock and Set tries umtx.RLock).
+func (s *CacheSuite) TestAddedFuncCanCallSetFromUpdate() {
+	require := s.Require()
+
+	cc := New[int, int](time.Second)
+	cc.Set(1, 0)
+
+	done := make(chan struct{})
+	cc.AddedFunc(func(key, val int) {
+		if key == 1 && val > 0 {
+			cc.Set(2, 999)
+			close(done)
+		}
+	})
+
+	cc.Update(1, func(v int) int { return v + 1 })
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		s.Fail("deadlock: addedFunc calling Set from Update never completed")
+	}
+
+	v, err := cc.Get(2)
+	require.NoError(err)
+	require.Equal(999, v)
+}
+
 func (s *CacheSuite) TestConcurrentUpdate() {
 	var (
 		validate = s.Assert()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tunein/go-cache
 
-go 1.24
+go 1.25
 
 require github.com/stretchr/testify v1.11.1
 

--- a/singlecall.go
+++ b/singlecall.go
@@ -34,8 +34,7 @@ type Group[TKey comparable, TValue any] struct {
 // sure that only one execution is in-flight for a given key at a
 // time. If a duplicate comes in, the duplicate caller waits for the
 // original to complete and receives the same results.
-func (g *Group[TKey, TValue]) Do(key TKey, fn func() (TValue, error), isWait bool) (res TValue, dupl bool, err error) {
-	var def TValue
+func (g *Group[TKey, TValue]) Do(key TKey, fn func() (TValue, error)) (res TValue, dupl bool, err error) {
 	g.mtx.Lock()
 	v, err := g.c.get(key)
 	if err == nil {
@@ -47,9 +46,6 @@ func (g *Group[TKey, TValue]) Do(key TKey, fn func() (TValue, error), isWait boo
 	}
 	if c, ok := g.m[key]; ok {
 		g.mtx.Unlock()
-		if !isWait {
-			return def, false, ErrNotFound
-		}
 		c.wg.Wait()
 		return c.val, false, c.err
 	}
@@ -57,10 +53,6 @@ func (g *Group[TKey, TValue]) Do(key TKey, fn func() (TValue, error), isWait boo
 	c.wg.Add(1)
 	g.m[key] = c
 	g.mtx.Unlock()
-	if !isWait {
-		go func() { _, _ = g.call(c, key, fn) }()
-		return def, false, ErrNotFound
-	}
 	v, err = g.call(c, key, fn)
 	return v, true, err
 }


### PR DESCRIPTION
- check for expired items on set() and remove them (in a separate goroutine to avoid blocking the caller) - do that not more often than every `ttl` interval to avoid useless runs.

-  Potential goroutine leak via dead-code path in singlecall.go. Group.Do had an isWait=false branch that spawned a goroutine to run the user-supplied loader function. This path was completely unreachable from the public API (every call chain passes isWait=true), but if it were ever triggered by a blocking loader, the goroutine would leak indefinitely.

-  Data race in Has() fix

- get() race fix. The expired-item deletion path dropped the read lock, then re-acquired a write lock and deleted unconditionally. A concurrent Set could write a fresh value in that window, which get would then destroy. Fixed by re-reading the entry under the write lock before deleting — only delete if the item is still expired

- tests and security vulnerability jobs fix in CI/CD